### PR TITLE
[bug fix, n/a] wait for rabbit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:10
 MAINTAINER davesag@gmail.com
 
 WORKDIR /amqp-event-tester
@@ -9,5 +9,6 @@ RUN npm install
 
 COPY src src
 COPY index.js index.js
+COPY start.sh start.sh
 
-ENTRYPOINT ["npm" , "start" ]
+ENTRYPOINT ["./start.sh" ]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ You may add environment variables to your local `.env` file
 
     npm start
 
+**Note**: The Dockerised version will run the script `start.sh` to start the service, as this will wait for RabbitMQ to start.  This is important when running this on a CI system.
+
 ### Test it
 
 * `npm test` — runs the unit tests (quick)

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+if [ -z "${AMQP_URL}" ];
+then
+URL="127.0.0.1"
+else
+URL="${AMQP_URL:7}"
+fi
+
+until bash -c "cat < /dev/null > /dev/tcp/${URL}/5672"; do
+  >&2 echo "Rabbit MQ not up yet on ${URL}"
+  sleep 1
+done
+
+echo "Rabbit MQ is up on ${URL}"
+
+npm start


### PR DESCRIPTION
When running this in a docker image on CircleCI it was not waiting for Rabbit to start, causing a build failure.
